### PR TITLE
fix: moving the event loop fixture

### DIFF
--- a/tests/adapter/out/conftest.py
+++ b/tests/adapter/out/conftest.py
@@ -1,7 +1,5 @@
 import os
-import asyncio
 
-import pytest
 import pytest_asyncio
 from testcontainers.postgres import PostgresContainer
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,16 +15,6 @@ from src.techlog_article.common.database import models
 # reference: https://mariogarcia.github.io/blog/2019/10/pytest_fixtures.html
 
 POSTGRES_VERSION = "15.0"
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-
-    yield loop
-
-    loop.close()
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """
+    Since we'll use a db_session as session-scoped object, the event loop must
+    also be of the same scope
+
+    At the beginning, this fixture was in adapter/out, which caused early-cleanup
+    of the eventloop as soon as all the tests in adapter/out have finished.
+
+    Therefore, this eventloop fixture must be at the top level of the test directories.
+
+    for details see:
+    https://pytest-asyncio.readthedocs.io/en/latest/reference/fixtures.html#event-loop
+    """
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+
+    yield loop
+
+    loop.close()


### PR DESCRIPTION
fix the problem of early cleanup of the test event loop fixture